### PR TITLE
feat: enum schemaObject.type 类型做兼容: 对数组中元素字符串和数字类型单独处理

### DIFF
--- a/src/generator/serviceGenarator.ts
+++ b/src/generator/serviceGenarator.ts
@@ -75,7 +75,8 @@ import {
   getLastRefName,
   getRefName,
   handleDuplicateTypeNames,
-  isAllNumeric,
+  isAllNumber,
+  isAllString,
   isArraySchemaObject,
   isBinaryArraySchemaObject,
   isNonArraySchemaObject,
@@ -1073,8 +1074,10 @@ export default class ServiceGenerator {
     let enumStr = '';
     let enumLabelTypeStr = '';
 
-    if (numberEnum.includes(schemaObject.type) || isAllNumeric(enumArray)) {
+    if (numberEnum.includes(schemaObject.type) || isAllNumber(enumArray)) {
       enumStr = `{${map(enumArray, (value) => `"NUMBER_${value}"=${Number(value)}`).join(',')}}`;
+    } else if (isAllString(enumArray)) {
+      enumStr = `{${map(enumArray, (value) => `"STRING_${value}"="${value}"`).join(',')}}`;
     } else {
       enumStr = `{${map(enumArray, (value) => `${value}="${value}"`).join(',')}}`;
     }
@@ -1093,8 +1096,10 @@ export default class ServiceGenerator {
         return `${value}:"${enumLabel}"`;
       }).join(',')}}`;
     } else {
-      if (numberEnum.includes(schemaObject.type) || isAllNumeric(enumArray)) {
+      if (numberEnum.includes(schemaObject.type) || isAllNumber(enumArray)) {
         enumLabelTypeStr = `{${map(enumArray, (value) => `"NUMBER_${value}":${Number(value)}`).join(',')}}`;
+      } else if (isAllString(enumArray)) {
+        enumLabelTypeStr = `{${map(enumArray, (value) => `"STRING_${value}":"${value}"`).join(',')}}`;
       } else {
         enumLabelTypeStr = `{${map(enumArray, (value) => `${value}:"${value}"`).join(',')}}`;
       }

--- a/src/generator/serviceGenarator.ts
+++ b/src/generator/serviceGenarator.ts
@@ -76,7 +76,7 @@ import {
   getRefName,
   handleDuplicateTypeNames,
   isAllNumber,
-  isAllString,
+  isAllNumeric,
   isArraySchemaObject,
   isBinaryArraySchemaObject,
   isNonArraySchemaObject,
@@ -1076,8 +1076,8 @@ export default class ServiceGenerator {
 
     if (numberEnum.includes(schemaObject.type) || isAllNumber(enumArray)) {
       enumStr = `{${map(enumArray, (value) => `"NUMBER_${value}"=${Number(value)}`).join(',')}}`;
-    } else if (isAllString(enumArray)) {
-      enumStr = `{${map(enumArray, (value) => `"STRING_${value}"="${value}"`).join(',')}}`;
+    } else if (isAllNumeric(enumArray)) {
+      enumStr = `{${map(enumArray, (value) => `"STRING_NUMBER_${value}"="${value}"`).join(',')}}`;
     } else {
       enumStr = `{${map(enumArray, (value) => `${value}="${value}"`).join(',')}}`;
     }
@@ -1098,8 +1098,8 @@ export default class ServiceGenerator {
     } else {
       if (numberEnum.includes(schemaObject.type) || isAllNumber(enumArray)) {
         enumLabelTypeStr = `{${map(enumArray, (value) => `"NUMBER_${value}":${Number(value)}`).join(',')}}`;
-      } else if (isAllString(enumArray)) {
-        enumLabelTypeStr = `{${map(enumArray, (value) => `"STRING_${value}":"${value}"`).join(',')}}`;
+      } else if (isAllNumeric(enumArray)) {
+        enumLabelTypeStr = `{${map(enumArray, (value) => `"STRING_NUMBER_${value}":"${value}"`).join(',')}}`;
       } else {
         enumLabelTypeStr = `{${map(enumArray, (value) => `${value}:"${value}"`).join(',')}}`;
       }

--- a/src/generator/util.ts
+++ b/src/generator/util.ts
@@ -485,11 +485,6 @@ export function isAllNumeric(arr) {
   return every(arr, (item) => isString(item) && /^-?[0-9]+$/.test(item));
 }
 
-// 检查数组每一项是否都是字符串
-export function isAllString(arr) {
-  return every(arr, (item) => isString(item));
-}
-
 // 检查数组每一项是否都是数字
 export function isAllNumber(arr) {
   return every(arr, (item) => isNumber(item));

--- a/src/generator/util.ts
+++ b/src/generator/util.ts
@@ -8,6 +8,7 @@ import {
   isBoolean,
   isEmpty,
   isNull,
+  isNumber,
   isObject,
   isString,
   isUndefined,
@@ -482,4 +483,14 @@ export function resolveRefs(obj: OpenAPIObject, fields: string[]) {
 
 export function isAllNumeric(arr) {
   return every(arr, (item) => isString(item) && /^-?[0-9]+$/.test(item));
+}
+
+// 检查数组每一项是否都是字符串
+export function isAllString(arr) {
+  return every(arr, (item) => isString(item));
+}
+
+// 检查数组每一项是否都是数字
+export function isAllNumber(arr) {
+  return every(arr, (item) => isNumber(item));
 }


### PR DESCRIPTION
schemaobject.type 的类型是 0 | 1
转换为：

```
export enum FlagEnum {
  'NUMBER_0' = 0,
  'NUMBER_1' = 1,
}

export type IFlagEnum = keyof typeof FlagEnum;
```
使用：
```
export function displayFlagEnum(field: API.IFlagEnum) {
  return { NUMBER_0: 0, NUMBER_1: 1 }[field];
}
```