### PR TITLE
feat: 解析枚举描述生成枚举标签

### DIFF
--- a/README-en_US.md
+++ b/README-en_US.md
@@ -204,6 +204,7 @@ $ openapi --help
     --isTranslateToEnglishTag <boolean> translate chinese tag name to english tag name (default: false)
     --isOnlyGenTypeScriptType <boolean> only generate typescript type (default: false)
     --isCamelCase <boolean>             camelCase naming of controller files and request client (default: true)
+    --isSupportParseEnumDesc <boolean>  parse enum description to generate enum label (default: false)
     -h, --help                          display help for command
 ```
 
@@ -240,6 +241,7 @@ openapi -i ./spec.json -o ./apis
 | isTranslateToEnglishTag | no | boolean | false | translate chinese tag name to english tag name |
 | isOnlyGenTypeScriptType | no | boolean | false | only generate typescript type |
 | isCamelCase | no | boolean | true | camelCase naming of controller files and request client |
+| isSupportParseEnumDesc | no | boolean | false | parse enum description to generate enum label, format example: `UserRole:User(Normal User)=0,Agent(Agent)=1,Admin(Administrator)=2` |
 | hook | no | [Custom Hook](#Custom-Hook) | - | custom hook |
 
 ## Custom Hook

--- a/README.md
+++ b/README.md
@@ -204,6 +204,9 @@ $ openapi --help
     --isTranslateToEnglishTag <boolean> translate chinese tag name to english tag name (default: false)
     --isOnlyGenTypeScriptType <boolean> only generate typescript type (default: false)
     --isCamelCase <boolean>             camelCase naming of controller files and request client (default: true)
+    --isSupportParseEnumDesc <boolean>  parse enum description to generate enum label (default: false)
+    --includeDescEnums <(string|RegExp)[]>   generate code from include enums
+    --excludeDescEnums <(string|RegExp)[]>   generate code from exclude enums, if includeDescEnums is not empty, this value is invalid
     -h, --help                          display help for command
 ```
 
@@ -240,6 +243,7 @@ openapi --i ./spec.json --o ./apis
 | isTranslateToEnglishTag | 否 | boolean | false | 将中文 tag 名称翻译成英文 tag 名称 |
 | isOnlyGenTypeScriptType | 否 | boolean | false | 仅生成 typescript 类型 |
 | isCamelCase | 否 | boolean | true | 小驼峰命名文件和请求函数 |
+| isSupportParseEnumDesc | 否 | boolean | false | 解析枚举描述生成枚举标签，格式参考：`系统用户角色:User(普通用户)=0,Agent(经纪人)=1,Admin(管理员)=2` |
 | hook | 否 | [Custom Hook](#Custom-Hook) | - | 自定义 hook |
 
 ## 自定义 Hook

--- a/src/generator/serviceGenarator.ts
+++ b/src/generator/serviceGenarator.ts
@@ -90,6 +90,7 @@ import {
   isReferenceObject,
   isSchemaObject,
   markAllowedSchema,
+  parseDescriptionEnum,
   replaceDot,
   resolveFunctionName,
   resolveRefs,
@@ -1122,7 +1123,16 @@ export default class ServiceGenerator {
     let enumLabelTypeStr = '';
 
     if (numberEnum.includes(schemaObject.type) || isAllNumber(enumArray)) {
-      enumStr = `{${map(enumArray, (value) => `"NUMBER_${value}"=${Number(value)}`).join(',')}}`;
+      if (this.config.isSupportParseEnumDesc && schemaObject.description) {
+        const enumMap = parseDescriptionEnum(schemaObject.description);
+        enumStr = `{${map(enumArray, (value) => {
+          const enumLabel = enumMap.get(Number(value));
+          return `${enumLabel}=${Number(value)}`;
+        }).join(',')}}`;
+        log('EnumDesc enumStr', enumStr);
+      } else {
+        enumStr = `{${map(enumArray, (value) => `"NUMBER_${value}"=${Number(value)}`).join(',')}}`;
+      }
     } else if (isAllNumeric(enumArray)) {
       enumStr = `{${map(enumArray, (value) => `"STRING_NUMBER_${value}"="${value}"`).join(',')}}`;
     } else {
@@ -1153,7 +1163,15 @@ export default class ServiceGenerator {
       }).join(',')}}`;
     } else {
       if (numberEnum.includes(schemaObject.type) || isAllNumber(enumArray)) {
-        enumLabelTypeStr = `{${map(enumArray, (value) => `"NUMBER_${value}":${Number(value)}`).join(',')}}`;
+        if (this.config.isSupportParseEnumDesc && schemaObject.description) {
+          const enumMap = parseDescriptionEnum(schemaObject.description);
+          enumLabelTypeStr = `{${map(enumArray, (value) => {
+            const enumLabel = enumMap.get(Number(value));
+            return `"${enumLabel}":${Number(value)}`;
+          }).join(',')}}`;
+        } else {
+          enumLabelTypeStr = `{${map(enumArray, (value) => `"NUMBER_${value}":${Number(value)}`).join(',')}}`;
+        }
       } else if (isAllNumeric(enumArray)) {
         enumLabelTypeStr = `{${map(enumArray, (value) => `"STRING_NUMBER_${value}":"${value}"`).join(',')}}`;
       } else {

--- a/src/index.ts
+++ b/src/index.ts
@@ -132,6 +132,10 @@ export type GenerateServiceProps = {
    */
   isCamelCase?: boolean;
   /**
+   * 是否使用 description 中的枚举定义
+   */
+  isSupportParseEnumDesc?: boolean;
+  /**
    * 命名空间名称，默认为API，不需要关注
    */
   namespace?: string;
@@ -274,6 +278,7 @@ export async function generateService({
       nullable: false,
       isOnlyGenTypeScriptType: false,
       isCamelCase: true,
+      isSupportParseEnumDesc: false,
       ...rest,
     },
     openAPI

--- a/test/example-files/openapi-desc-enum.json
+++ b/test/example-files/openapi-desc-enum.json
@@ -1,0 +1,165 @@
+{
+  "openapi": "3.0.1",
+  "info": {
+    "title": "DeepSprite.House",
+    "description": "DeepSprite.House",
+    "version": "v9.0.2"
+  },
+  "servers": [
+    {
+      "url": "http://localhost:8010",
+      "description": ""
+    }
+  ],
+  "paths": {
+    "/api/sys/user/get-user-info": {
+      "get": {
+        "tags": ["user"],
+        "summary": "获取用户信息",
+        "operationId": "api-sys-user-get-user-info-get",
+        "parameters": [
+          {
+            "name": "userId",
+            "in": "query",
+            "description": "",
+            "schema": {
+              "type": "integer",
+              "format": "int64"
+            }
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "OK",
+            "content": {
+              "text/plain": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultOutputUserInfoOutput"
+                }
+              },
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultOutputUserInfoOutput"
+                }
+              },
+              "text/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ResultOutputUserInfoOutput"
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  },
+  "components": {
+    "schemas": {
+      "ResultOutputString": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "是否成功标记"
+          },
+          "code": {
+            "type": "string",
+            "description": "编码",
+            "nullable": true
+          },
+          "msg": {
+            "type": "string",
+            "description": "消息",
+            "nullable": true
+          },
+          "data": {
+            "type": "string",
+            "description": "数据",
+            "nullable": true
+          }
+        },
+        "additionalProperties": false,
+        "description": "结果输出"
+      },
+      "ResultOutputUserInfoOutput": {
+        "type": "object",
+        "properties": {
+          "success": {
+            "type": "boolean",
+            "description": "是否成功标记"
+          },
+          "code": {
+            "type": "string",
+            "description": "编码",
+            "nullable": true
+          },
+          "msg": {
+            "type": "string",
+            "description": "消息",
+            "nullable": true
+          },
+          "data": {
+            "$ref": "#/components/schemas/UserInfoOutput"
+          }
+        },
+        "additionalProperties": false,
+        "description": "结果输出"
+      },
+      "SortOrder": {
+        "enum": [0, 1],
+        "type": "integer",
+        "description": "排序方式:Asc=0,Desc=1",
+        "format": "int32"
+      },
+      "SysUserRole": {
+        "enum": [0, 1, 2],
+        "type": "integer",
+        "description": "系统用户角色:User(普通用户)=0,Agent(经纪人)=1,Admin(管理员)=2",
+        "format": "int32"
+      },
+      "UserInfoOutput": {
+        "type": "object",
+        "properties": {
+          "nickName": {
+            "type": "string",
+            "description": "昵称",
+            "nullable": true
+          },
+          "avatar": {
+            "type": "string",
+            "description": "头像",
+            "nullable": true
+          },
+          "phone": {
+            "type": "string",
+            "description": "手机号",
+            "nullable": true
+          },
+          "role": {
+            "$ref": "#/components/schemas/SysUserRole"
+          }
+        },
+        "additionalProperties": false
+      }
+    },
+    "securitySchemes": {
+      "Bearer": {
+        "type": "apiKey",
+        "description": "Value: Bearer {token}",
+        "name": "Authorization",
+        "in": "header"
+      }
+    }
+  },
+  "security": [
+    {
+      "Bearer": []
+    }
+  ],
+  "tags": [
+    {
+      "name": "user",
+      "description": "用户服务"
+    }
+  ]
+}

--- a/test/test.js
+++ b/test/test.js
@@ -61,7 +61,9 @@ const gen = async () => {
       // 自定义类型名
       customTypeName: (data) => {
         const { operationId } = data;
-        const funName = operationId ? operationId[0].toUpperCase() + operationId.substring(1) : '';
+        const funName = operationId
+          ? operationId[0].toUpperCase() + operationId.substring(1)
+          : '';
         const tag = data?.tags?.[0];
 
         return `${tag ? tag : ''}${funName}`;
@@ -156,7 +158,7 @@ const gen = async () => {
   await openAPI.generateService({
     schemaPath: `${__dirname}/example-files/openapi-ref-encode-character.json`,
     serversPath: './apis/ref-encode-character',
-    includeTags: ["商品基础管理"],
+    includeTags: ['商品基础管理'],
   });
 
   // 测试支持 apifox x-run-in-apifox
@@ -184,6 +186,12 @@ const gen = async () => {
   await openAPI.generateService({
     schemaPath: `${__dirname}/example-files/openapi-number-enum.json`,
     serversPath: './apis/number-enum',
+  });
+
+  // 测试 number类型 枚举，使用 desc 解析枚举
+  await openAPI.generateService({
+    schemaPath: `${__dirname}/example-files/openapi-desc-enum.json`,
+    serversPath: './apis/desc-enum',
   });
 
   // 测试支持 apifox x-apifox-enum
@@ -218,7 +226,7 @@ const gen = async () => {
   // check 文件生成
   const fileControllerStr = fs.readFileSync(
     path.join(__dirname, 'apis/file/fileController.ts'),
-    'utf8',
+    'utf8'
   );
   assert(fileControllerStr.indexOf('!(item instanceof File)') > 0);
   assert(fileControllerStr.indexOf(`'multipart/form-data'`) > 0);


### PR DESCRIPTION
解析枚举描述生成枚举标签，格式参考：`系统用户角色:User(普通用户)=0,Agent(经纪人)=1,Admin(管理员)=2` ,类似格式最终解析成
0 => "User"
1 => "Agent"
2 => "Admin"
由于resolveEnumObject(schemaObject: SchemaObject)方法没有对象的名称，暂时没有添加黑白名单功能