### PR TITLE
feat: priorityRule 为 both 和 include 的时候都设置includeTags, includePaths 默认值为 [/.*/g]

### DIFF
--- a/.changeset/plain-yaks-warn.md
+++ b/.changeset/plain-yaks-warn.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-request': patch
+---
+
+priorityRule 为 both 和 include 的时候都设置includeTags, includePaths 的默认值为[/.*/g]

--- a/src/index.ts
+++ b/src/index.ts
@@ -300,7 +300,8 @@ export async function generateService({
         ? map(includeTags, (item) =>
             typeof item === 'string' ? item.toLowerCase() : item
           )
-        : priorityRule === PriorityRule.include
+        : priorityRule === PriorityRule.include ||
+            priorityRule === PriorityRule.both
           ? [/.*/g]
           : null,
       excludeTags: excludeTags

--- a/src/index.ts
+++ b/src/index.ts
@@ -255,6 +255,8 @@ export async function generateService({
   mockFolder,
   includeTags,
   excludeTags,
+  includePaths,
+  excludePaths,
   authorization,
   isTranslateToEnglishTag,
   priorityRule = PriorityRule.include,
@@ -304,8 +306,21 @@ export async function generateService({
             priorityRule === PriorityRule.both
           ? [/.*/g]
           : null,
+      includePaths: includePaths
+        ? map(includePaths, (item) =>
+            typeof item === 'string' ? item.toLowerCase() : item
+          )
+        : priorityRule === PriorityRule.include ||
+            priorityRule === PriorityRule.both
+          ? [/.*/g]
+          : null,
       excludeTags: excludeTags
         ? map(excludeTags, (item) =>
+            typeof item === 'string' ? item.toLowerCase() : item
+          )
+        : null,
+      excludePaths: excludePaths
+        ? map(excludePaths, (item) =>
             typeof item === 'string' ? item.toLowerCase() : item
           )
         : null,


### PR DESCRIPTION
当前include 的时候设置了默认值， both 是包含include和 exclude 两种模式，那么是不是也可以考虑给 includeTags 设置上相同的默认值。 

尤其是看到前面有一次提交只生成includePaths包含的types的逻辑后，当前项目已经有很多的测试生成的类型都缺失了。 为了尽可能保证新增api和之前的兼容性，建议这里添加上默认值。