### PR TITLE
fix: hook中取值错误

### DIFF
--- a/.changeset/rare-loops-try.md
+++ b/.changeset/rare-loops-try.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-request': patch
+---
+
+fix: 新增的 enum label hook中取变量错误

--- a/src/generator/serviceGenarator.ts
+++ b/src/generator/serviceGenarator.ts
@@ -401,7 +401,7 @@ export default class ServiceGenerator {
           customTemplate: !!hookCustomTemplateService,
           list: hookCustomTemplateService
             ? hookCustomTemplateService(enums, this.config)
-            : enums,
+            : displayTypeLabels,
           namespace: this.config.namespace,
           interfaceFileName: interfaceFileName,
         }


### PR DESCRIPTION
https://github.com/openapi-ui/openapi-ts-request/pull/381 中枚举翻译的hooks 的取值不正确