### PR TITLE
fix: 修复引用类型返回值在 types.ts中也包含了 namespace 的问题

### DIFF
--- a/.changeset/tender-pianos-jump.md
+++ b/.changeset/tender-pianos-jump.md
@@ -1,0 +1,5 @@
+---
+'openapi-ts-request': patch
+---
+
+fix: 修复引用类型返回值在 types.ts中也包含了 namespace 的问题

--- a/src/generator/serviceGenarator.ts
+++ b/src/generator/serviceGenarator.ts
@@ -641,6 +641,10 @@ export default class ServiceGenerator {
               const params =
                 this.getParamsTP(newApi.parameters, newApi.path) || {};
               const body = this.getBodyTP(
+                newApi.requestBody as RequestBodyObject,
+                this.config.namespace
+              );
+              const bodyWithoutNamespace = this.getBodyTP(
                 newApi.requestBody as RequestBodyObject
               );
               const response = this.getResponseTP(newApi.responses);
@@ -665,7 +669,7 @@ export default class ServiceGenerator {
                 const bodyName = upperFirst(`${functionName}Body`);
                 this.interfaceTPConfigs.push({
                   typeName: bodyName,
-                  type: body?.type,
+                  type: bodyWithoutNamespace?.type,
                   isEnum: false,
                   props: [],
                 });
@@ -931,7 +935,7 @@ export default class ServiceGenerator {
     return resolveTypeName(`${namespace}${typeName ?? data.operationId}Params`);
   }
 
-  private getBodyTP(requestBody: RequestBodyObject) {
+  private getBodyTP(requestBody: RequestBodyObject, namespace?: string) {
     const reqBody = this.resolveRefObject(requestBody);
 
     if (isEmpty(reqBody)) {
@@ -958,7 +962,7 @@ export default class ServiceGenerator {
     const bodySchema = {
       mediaType,
       required,
-      type: this.getType(schema, this.config.namespace),
+      type: this.getType(schema, namespace),
       isAnonymous: false,
     };
 

--- a/test/__snapshots__/common/小驼峰命名文件和请求函数.snap
+++ b/test/__snapshots__/common/小驼峰命名文件和请求函数.snap
@@ -366,7 +366,7 @@ export type User = {
   userStatus?: number;
 };
 
-export type UserCreateWithListUsingPostBody = API.User[];
+export type UserCreateWithListUsingPostBody = User[];
 
 export type userLoginUsingGetParams = {
   /** The user name for login */

--- a/test/__snapshots__/common/支持 null 类型作为默认值.snap
+++ b/test/__snapshots__/common/支持 null 类型作为默认值.snap
@@ -366,7 +366,7 @@ export type User = {
   userStatus: number | null;
 };
 
-export type UserCreateWithListUsingPostBody = API.User[];
+export type UserCreateWithListUsingPostBody = User[];
 
 export type userLoginUsingGetParams = {
   /** The user name for login */

--- a/test/__snapshots__/common/正常命名文件和请求函数.snap
+++ b/test/__snapshots__/common/正常命名文件和请求函数.snap
@@ -497,7 +497,7 @@ export type User = {
   userStatus?: number;
 };
 
-export type UserCreateWithListUsingPostBody = API.User[];
+export type UserCreateWithListUsingPostBody = User[];
 
 export type userLoginUsingGetParams = {
   /** The user name for login */

--- a/test/__snapshots__/common/测试将中文 tag 名称翻译成英文 tag 名称.snap
+++ b/test/__snapshots__/common/测试将中文 tag 名称翻译成英文 tag 名称.snap
@@ -344,7 +344,7 @@ export type User = {
   userStatus?: number;
 };
 
-export type UserCreateWithListUsingPostBody = API.User[];
+export type UserCreateWithListUsingPostBody = User[];
 
 export type userLoginUsingGetParams = {
   /** The user name for login */

--- a/test/__snapshots__/common/测试生成 JSON Schemas.snap
+++ b/test/__snapshots__/common/测试生成 JSON Schemas.snap
@@ -4841,7 +4841,7 @@ export type v1ApiAppAppIdDatasetsUsingDeleteParams = {
   datasetID: string;
 };
 
-export type V1ApiAppAppIdDatasetsUsingPostBody = API.AppDatasets[];
+export type V1ApiAppAppIdDatasetsUsingPostBody = AppDatasets[];
 
 export type v1ApiAppAppIdDatasetsUsingPostParams = {
   /** 应用id */
@@ -5233,7 +5233,7 @@ export type v2ApiWorkspacesRecommendedMessageIdDetailsUsingGetParams = {
 };
 
 export type V2ApiWorkspacesWorkspaceIdAppAppIdDatasetsJoinUsingPostBody =
-  API.AppDatasets[];
+  AppDatasets[];
 
 export type v2ApiWorkspacesWorkspaceIdAppAppIdDatasetsJoinUsingPostParams = {
   /** 空间ID */

--- a/test/__snapshots__/common/测试生成 react-query 的 vue 模式.snap
+++ b/test/__snapshots__/common/测试生成 react-query 的 vue 模式.snap
@@ -4276,7 +4276,7 @@ export type v1ApiAppAppIdDatasetsUsingDeleteParams = {
   datasetID: string;
 };
 
-export type V1ApiAppAppIdDatasetsUsingPostBody = API.AppDatasets[];
+export type V1ApiAppAppIdDatasetsUsingPostBody = AppDatasets[];
 
 export type v1ApiAppAppIdDatasetsUsingPostParams = {
   /** 应用id */
@@ -4668,7 +4668,7 @@ export type v2ApiWorkspacesRecommendedMessageIdDetailsUsingGetParams = {
 };
 
 export type V2ApiWorkspacesWorkspaceIdAppAppIdDatasetsJoinUsingPostBody =
-  API.AppDatasets[];
+  AppDatasets[];
 
 export type v2ApiWorkspacesWorkspaceIdAppAppIdDatasetsJoinUsingPostParams = {
   /** 空间ID */

--- a/test/__snapshots__/common/测试生成 react-query.snap
+++ b/test/__snapshots__/common/测试生成 react-query.snap
@@ -4276,7 +4276,7 @@ export type v1ApiAppAppIdDatasetsUsingDeleteParams = {
   datasetID: string;
 };
 
-export type V1ApiAppAppIdDatasetsUsingPostBody = API.AppDatasets[];
+export type V1ApiAppAppIdDatasetsUsingPostBody = AppDatasets[];
 
 export type v1ApiAppAppIdDatasetsUsingPostParams = {
   /** 应用id */
@@ -4668,7 +4668,7 @@ export type v2ApiWorkspacesRecommendedMessageIdDetailsUsingGetParams = {
 };
 
 export type V2ApiWorkspacesWorkspaceIdAppAppIdDatasetsJoinUsingPostBody =
-  API.AppDatasets[];
+  AppDatasets[];
 
 export type v2ApiWorkspacesWorkspaceIdAppAppIdDatasetsJoinUsingPostParams = {
   /** 空间ID */

--- a/test/__snapshots__/common/测试解析 swagger.yaml_openapi.yaml.snap
+++ b/test/__snapshots__/common/测试解析 swagger.yaml_openapi.yaml.snap
@@ -395,9 +395,9 @@ export type User = {
   userStatus?: number;
 };
 
-export type UserCreateWithArrayUsingPostBody = API.User[];
+export type UserCreateWithArrayUsingPostBody = User[];
 
-export type UserCreateWithListUsingPostBody = API.User[];
+export type UserCreateWithListUsingPostBody = User[];
 
 export type userLoginUsingGetParams = {
   /** The user name for login */

--- a/test/__snapshots__/common/测试设置 path 前缀.snap
+++ b/test/__snapshots__/common/测试设置 path 前缀.snap
@@ -395,9 +395,9 @@ export type User = {
   userStatus?: number;
 };
 
-export type UserCreateWithArrayUsingPostBody = API.User[];
+export type UserCreateWithArrayUsingPostBody = User[];
 
-export type UserCreateWithListUsingPostBody = API.User[];
+export type UserCreateWithListUsingPostBody = User[];
 
 export type userLoginUsingGetParams = {
   /** The user name for login */

--- a/test/__snapshots__/common/生成枚举翻译, 生成 type 翻译.snap
+++ b/test/__snapshots__/common/生成枚举翻译, 生成 type 翻译.snap
@@ -4511,7 +4511,7 @@ export type v1ApiAppAppIdDatasetsUsingDeleteParams = {
   datasetID: string;
 };
 
-export type V1ApiAppAppIdDatasetsUsingPostBody = API.AppDatasets[];
+export type V1ApiAppAppIdDatasetsUsingPostBody = AppDatasets[];
 
 export type v1ApiAppAppIdDatasetsUsingPostParams = {
   /** 应用id */
@@ -4903,7 +4903,7 @@ export type v2ApiWorkspacesRecommendedMessageIdDetailsUsingGetParams = {
 };
 
 export type V2ApiWorkspacesWorkspaceIdAppAppIdDatasetsJoinUsingPostBody =
-  API.AppDatasets[];
+  AppDatasets[];
 
 export type v2ApiWorkspacesWorkspaceIdAppAppIdDatasetsJoinUsingPostParams = {
   /** 空间ID */


### PR DESCRIPTION
更新后又发现一个问题，types.ts 中生成的类型别名也带上了 namespace, 导致类型错误。

修改后更新了一遍快照确认了一次， 都是预期的修改。