### PR TITLE
feat: add option to cli for disabling interactive api generation

### DIFF
--- a/.changeset/dry-guests-decide.md
+++ b/.changeset/dry-guests-decide.md
@@ -1,0 +1,5 @@
+---
+"openapi-ts-request": patch
+---
+
+perf: add option to cli for disabling interactive api generation

--- a/src/bin/cli.ts
+++ b/src/bin/cli.ts
@@ -6,11 +6,12 @@ import type { GenerateServiceProps } from '../index';
 import { generateService } from '../index';
 import { logError } from '../log';
 import { readConfig } from '../readConfig';
-import { createMultiselectOptions } from './utils';
+import { createMultiselectOptions, parseInteractiveMode } from './utils';
 
 program
   .option('-cfn, --configFileName <string>', 'config file name')
-  .option('-cfp, --configFilePath <string>', 'config file path');
+  .option('-cfp, --configFilePath <string>', 'config file path')
+  .option('-i, --interactive <boolean>', 'enable interactive mode', true);
 
 program.parse();
 const options = program.opts();
@@ -37,7 +38,7 @@ async function run() {
       /** 是否交互式 */
       let isInteractive = false;
 
-      if (configs.length > 1) {
+      if (configs.length > 1 && parseInteractiveMode(options.interactive)) {
         // 有多个配置，则交互式选择
         isInteractive = true;
 

--- a/src/bin/openapi.ts
+++ b/src/bin/openapi.ts
@@ -10,7 +10,7 @@ import { generateService } from '../index';
 import { logError } from '../log';
 import { readConfig } from '../readConfig';
 import type { IPriorityRule, IReactQueryMode } from '../type';
-import { createMultiselectOptions } from './utils';
+import { createMultiselectOptions, parseInteractiveMode } from './utils';
 
 const params = program
   .name('openapi')
@@ -107,6 +107,7 @@ const params = program
     '--supportParseEnumDescByReg <string>',
     'custom regex for parsing enum description'
   )
+  .option('-i, --interactive <boolean>', 'enable interactive mode', true)
   .parse(process.argv)
   .opts();
 
@@ -189,7 +190,7 @@ async function run() {
       /** 是否交互式 */
       let isInteractive = false;
 
-      if (configs.length > 1) {
+      if (configs.length > 1 && parseInteractiveMode(params.interactive)) {
         // 有多个配置，则交互式选择
         isInteractive = true;
 

--- a/src/bin/utils.ts
+++ b/src/bin/utils.ts
@@ -13,3 +13,15 @@ export function createMultiselectOptions(
       ('schemaPath' in config ? config.schemaPath : 'Apifox Config'),
   }));
 }
+
+export function parseInteractiveMode(value: unknown): boolean {
+  if (value === undefined) {
+    return true;
+  }
+
+  if (typeof value === 'boolean') {
+    return value;
+  }
+
+  return JSON.parse(value as string) === true;
+}

--- a/test/bin-utils.spec.ts
+++ b/test/bin-utils.spec.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+
+import { parseInteractiveMode } from '../src/bin/utils';
+
+describe('parseInteractiveMode', () => {
+  it('defaults interactive mode to enabled', () => {
+    expect(parseInteractiveMode(undefined)).toBe(true);
+  });
+
+  it('allows disabling interactive mode with false', () => {
+    expect(parseInteractiveMode('false')).toBe(false);
+  });
+});


### PR DESCRIPTION
有些场景下，比如工作流，需要让工具可以直接调用，不需要人参与。 
该PR增加了一个 -i, --interactive 参数，用于控制是不是启用交互式生成。默认值保持现在的启用。 